### PR TITLE
Fixed the WrapPanel control namespace in docs

### DIFF
--- a/docs/controls/WrapPanel.md
+++ b/docs/controls/WrapPanel.md
@@ -47,7 +47,7 @@ The following sample demonstrates how to add WrapPanel Control.
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Microsoft.Toolkit.Uwp.SampleApp.SamplePages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:wrapPanel="using:Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel"
+    xmlns:wrapPanel="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d">
 
     <Grid Background="{StaticResource Brush-Grey-05}">


### PR DESCRIPTION
The namespace for the control was not correct, the control lies in `Microsoft.Toolkit.Uwp.UI.Controls` namespace.