### PR TITLE
Fix minor docs bugs for gaze interaction library

### DIFF
--- a/docs/gaze/GazeInteractionLibrary.md
+++ b/docs/gaze/GazeInteractionLibrary.md
@@ -2,7 +2,7 @@
 title: Gaze Interaction Library
 author: harishsk
 description: The Gaze Interaction library contains a set of helper classes built on the Windows gaze input APIs to more easily leverage eye tracking and integrate gaze interactions into your UWP application. 
-keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, gaze, eye gaze, gaze input, gaze interaction, eye tracking, eye tracker
+keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, windows community toolkit, gaze, eye gaze, gaze input, gaze interaction, eye tracking, eye tracker
 ---
 
 # Gaze Interaction Library
@@ -130,7 +130,7 @@ For e.g.
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:gaze="using:Microsoft.Toolkit.UWP.Input.GazeInteraction"
+    xmlns:gaze="using:Microsoft.Toolkit.Uwp.Input.GazeInteraction"
     gaze:GazeInput.Interaction="Enabled"
     mc:Ignorable="d">
 ```
@@ -184,11 +184,11 @@ private void OnInvokeProgress(object sender, GazeProgressEventArgs e)
 
 <!-- All control/helper must at least have an example to show the use of Properties and Methods in your control/helper with the output -->
 <!-- Use <example> and <code> tags in C# to create a Propertie/method specific examples. For more info - https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/example -->
-<!-- Optional: Codes to achieve real-world use case with the output. For eg: Check https://docs.microsoft.com/en-us/windows/uwpcommunitytoolkit/animations/animationset#examples  -->
+<!-- Optional: Codes to achieve real-world use case with the output. For eg: Check https://docs.microsoft.com/en-us/windows/WindowsCommunityToolkit/animations/animationset#examples  -->
 
 ## Sample Code
 
-[GazeInteractionPage](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeInteraction/). You can see all of this in action in the [Windows Community Toolkit Sample App](https://www.microsoft.com/store/apps/9NBLGGH4TLCQ).
+[GazeInteractionPage](https://github.com/Microsoft/WindowsCommunityToolkit/tree/rel/3.0.0-preview/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeInteraction/). You can see all of this in action in the [Windows Community Toolkit Sample App](https://www.microsoft.com/store/apps/9NBLGGH4TLCQ).
 
 ## Requirements
 
@@ -199,7 +199,7 @@ private void OnInvokeProgress(object sender, GazeProgressEventArgs e)
 
 ## API Source Code
 
-* [Gaze Interaction Library source code](https://github.com/Microsoft/UWPCommunityToolkit/tree/rel/3.0.0-preview/Microsoft.Toolkit.Uwp.Input.GazeInteraction)
+* [Gaze Interaction Library source code](https://github.com/Microsoft/WindowsCommunityToolkit/tree/rel/3.0.0-preview/Microsoft.Toolkit.Uwp.Input.GazeInteraction)
 
 ## Related Topics
 


### PR DESCRIPTION
- namespace in sample had "UWP" instead of "Uwp", causing build break.
- urls pointed two master branch, which would 404 since master does not yet have eye gaze
- UwpCommunityToolkit is now WindowsCommunityToolki, so update urls accordingly